### PR TITLE
Fix small typo in googlecalendar comment

### DIFF
--- a/public/php/googlecalendar.php
+++ b/public/php/googlecalendar.php
@@ -57,7 +57,7 @@ $optParams = array(
 // Get our list of events
 $events = $service->events->listEvents($calendarId, $optParams);
 
-// A fuction for processing the various ways we are passed date and time by Google
+// A function for processing the various ways we are passed date and time by Google
 function normalizeEventTime($dateTime, $timeZone, $date, $targetTimeZone) {
   if (!empty($dateTime)) {
     $event = $dateTime;


### PR DESCRIPTION
## Summary
- fix a typo in `googlecalendar.php` comment

## Testing
- `php -l public/php/googlecalendar.php`

------
https://chatgpt.com/codex/tasks/task_e_685acf07ea3c832ca9f66d0b3ba8f132