### PR TITLE
Refactor proxy scripts

### DIFF
--- a/public/php/common.php
+++ b/public/php/common.php
@@ -1,0 +1,96 @@
+<?php
+// Common functions for proxy scripts
+
+// Return 403 Forbidden if this file is accessed directly via HTTP
+if (php_sapi_name() !== 'cli' && basename($_SERVER['PHP_SELF']) === basename(__FILE__)) {
+    http_response_code(403);
+    echo 'Forbidden';
+    exit;
+}
+
+/**
+ * Fetch data from an API endpoint using a Bearer token.
+ */
+function fetchFromApi(string $apiUrl, string $apiKey) {
+    $options = [
+        'http' => [
+            'header' => 'Authorization: Bearer ' . $apiKey,
+            'method' => 'GET',
+        ],
+    ];
+    $context = stream_context_create($options);
+    return @file_get_contents($apiUrl, false, $context);
+}
+
+/**
+ * Attempt to read cached data if it is still valid.
+ *
+ * @return string|false Cached JSON string or false if not usable
+ */
+function getCachedData(string $cacheFile, int $cacheDuration) {
+    if (!file_exists($cacheFile)) {
+        return false;
+    }
+
+    $cacheData = json_decode(file_get_contents($cacheFile), true);
+    if (!isset($cacheData['timestamp'], $cacheData['data'])) {
+        return false;
+    }
+
+    $cacheAge = time() - $cacheData['timestamp'];
+    if ($cacheAge > $cacheDuration) {
+        return false;
+    }
+
+    return $cacheData['data'];
+}
+
+/**
+ * Save API response to cache.
+ */
+function writeCache(string $cacheFile, string $response): void {
+    $cacheData = [
+        'timestamp' => time(),
+        'data' => $response,
+    ];
+    file_put_contents($cacheFile, json_encode($cacheData));
+}
+
+/**
+ * Proxy a request to a remote API with caching and fallback logic.
+ */
+function proxyRequest(string $apiUrl, string $apiKey, string $cacheFile, int $cacheDuration): void {
+    // return cached data if possible
+    $cached = getCachedData($cacheFile, $cacheDuration);
+    if ($cached !== false) {
+        header('Content-Type: application/json');
+        header('X-Data-Source: Cached');
+        echo $cached;
+        return;
+    }
+
+    $response = fetchFromApi($apiUrl, $apiKey);
+
+    if ($response === false) {
+        // if api call failed try serving stale cache
+        $stale = file_exists($cacheFile) ? json_decode(file_get_contents($cacheFile), true)['data'] ?? false : false;
+        if ($stale !== false) {
+            header('Content-Type: application/json');
+            header('X-Data-Source: Cached (Fallback)');
+            echo $stale;
+            return;
+        }
+
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to fetch data from Remote API']);
+        return;
+    }
+
+    // store and serve fresh response
+    writeCache($cacheFile, $response);
+    header('Content-Type: application/json');
+    header('X-Data-Source: Live');
+    echo $response;
+}
+
+?>

--- a/public/php/netdataproxy.php
+++ b/public/php/netdataproxy.php
@@ -1,9 +1,8 @@
 <?php
-
 /*
  * Description: A simple proxy script for the Netdata API.
- *     This script is not technically required as We can pull durectly from 
- *     the Netdata API however it allows us uptions as Netdata evolves and 
+ *     This script is not technically required as we can pull directly from
+ *     the Netdata API however it allows options as Netdata evolves and
  *     allows us to put extra protection in place as well as caching.
  *
  *     The script has a few additional advantages
@@ -17,7 +16,7 @@
  *     $cacheFile     = Path to the cache file
  *     $cacheDuration = How many seconds to cache the response
  *
- * Notes:  
+ * Notes:
  *
  */
 
@@ -27,67 +26,13 @@ $cacheFile = '../../cache/netdataproxy.cache';
 $cacheDuration = 14;
 
 include '../../config/netdataproxy.config';
+require_once 'common.php';
 
-// If apiKey is not set then don't even try doing anything
 if ($apiKey == "NotSet") {
     http_response_code(500);
     echo json_encode(["success" => "false","error" => "API Key not set"]);
     exit;
 }
 
-function fetchFromApi($apiUrl, $apiKey) {
-    $options = [
-        "http" => [
-            "header" => "Authorization: Bearer " . $apiKey,
-            "method" => "GET",
-        ],
-    ];
-    $context = stream_context_create($options);
-    return file_get_contents($apiUrl, false, $context);
-}
-
-// Check if cache file exists and is still valid
-if (file_exists($cacheFile)) {
-    $cacheData = json_decode(file_get_contents($cacheFile), true);
-    $cacheAge = time() - $cacheData['timestamp'];
-
-    // If cache is still valid, return cached content
-    if ($cacheAge <= $cacheDuration) {
-	header("Content-Type: application/json");
-        header("X-Data-Source: Cached");  
-        echo $cacheData['data'];
-        exit;
-    }
-}
-
-// Fetch new data from the API
-$response = fetchFromApi($apiUrl, $apiKey);
-
-if ($response === FALSE) {
-    // If API request fails and cache exists, return the cached content
-    if (isset($cacheData)) {
-	header("Content-Type: application/json");
-        header("X-Data-Source: Cached (Fallback)");
-        echo $cacheData['data'];
-        exit;
-    }
-
-    // If no cache exists, return an error
-    http_response_code(500);
-    echo json_encode(["error" => "Failed to fetch data from Remote API"]);
-    exit;
-}
-
-// Cache the response
-$cacheData = [
-    'timestamp' => time(),
-    'data' => $response,
-];
-file_put_contents($cacheFile, json_encode($cacheData));
-
-// Return the response
-header("Content-Type: application/json");
-header("X-Data-Source: Live");
-echo $response;
+proxyRequest($apiUrl, $apiKey, $cacheFile, $cacheDuration);
 ?>
-


### PR DESCRIPTION
## Summary
- reduce duplication between proxy PHP scripts
- centralize caching and fetch logic in `public/php/common.php`
- use new helper function `proxyRequest()`
- prevent direct web access to `public/php/common.php`

## Testing
- `php -l public/php/common.php`
- `php -l public/php/appbeatproxy.php`
- `php -l public/php/netdataproxy.php`


------
https://chatgpt.com/codex/tasks/task_e_685c1f56a244832cb146a190194be441