### PR TITLE
Add API key headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Uses Github Actions to deploy to a server via SSH. This also pulls in any depend
 This is very much configured for use by Dogsbody Technology with our endpoints hard coded in various files. Most of these settings can be overwritten using the settings below if needed. The aim is for there to be no need to fork the code.
 
 ### AppBeat
-* Just copy `config/appbeatproxy.config.sample` to `config/appbeatproxy.config` and edit the `$apiKey` variable to your API key found at https://my.appbeat.io/manage/account
+* Just copy `config/appbeatproxy.config.sample` to `config/appbeatproxy.config` and edit the `$apiHeaders` array with the HTTP headers needed for authentication. Examples:
+  * `['Authorization: Bearer YOUR_TOKEN']`
+  * `['X-Auth-Token: YOUR_TOKEN', 'X-Auth-Secret: YOUR_SECRET']`
 * Optionally the `$cacheFile` and `$cacheDuration` can be overwritten in this file
 
 ### Netdata

--- a/config/appbeatproxy.config.sample
+++ b/config/appbeatproxy.config.sample
@@ -1,7 +1,12 @@
 <?php
 
-/* your API key found at https://my.appbeat.io/manage/account */
+/*
+ * HTTP headers used for AppBeat authentication
+ * Example:
+ *     ['Authorization: Bearer YOUR_TOKEN']
+ * or  ['X-Auth-Token: YOUR_TOKEN', 'X-Auth-Secret: YOUR_SECRET']
+ */
 
-$apiKey = "NotSet"; 
+$apiHeaders = ['Authorization: Bearer NotSet'];
 
 ?>

--- a/config/netdataproxy.config.sample
+++ b/config/netdataproxy.config.sample
@@ -1,6 +1,13 @@
 <?php
 
+/*
+ * HTTP headers used to authenticate with your Netdata instance
+ * Example:
+ *     ['Authorization: Bearer YOUR_TOKEN']
+ * or  ['X-Auth-Token: TOKEN', 'X-Auth-Secret: SECRET']
+ */
+
 $apiUrl = "https://netdata.example.com/api/v2/nodes";
-$apiKey = "NotSet";
+$apiHeaders = ['Authorization: Bearer NotSet'];
 
 ?>

--- a/public/php/appbeatproxy.php
+++ b/public/php/appbeatproxy.php
@@ -5,12 +5,12 @@
  *       which means the API can't be read directly by a webpage.
  *     The script has a few additional advantages
  *       - We are caching the last results so we don't get rate limited
- *       - We can hide our API key in this script instead of the website
+ *       - We can hide our authentication headers in this script instead of the website
  *       - We add a header to show when the data is old
  *
  * Configuration:  The following variables can be set
  *     $apiUrl        = The API URL we are calling
- *     $apiKey        = The API Key
+ *     $apiHeaders    = An array of HTTP headers used for authentication
  *     $cacheFile     = Path to the cache file
  *     $cacheDuration = How many seconds to cache the response
  *
@@ -19,19 +19,19 @@
  */
 
 $apiUrl = "https://www.appbeat.io/API/v1/status";
-$apiKey = "NotSet";
+$apiHeaders = [];
 $cacheFile = '../../cache/appbeatproxy.cache';
 $cacheDuration = 30;  // maximum we are allowed
 
 include '../../config/appbeatproxy.config';
 require_once 'common.php';
 
-if ($apiKey == "NotSet") {
+if (empty($apiHeaders)) {
     http_response_code(500);
-    echo json_encode(["success" => "false","error" => "API Key not set"]);
+    echo json_encode(["success" => "false","error" => "API headers not set"]);
     exit;
 }
 
-proxyRequest($apiUrl, $apiKey, $cacheFile, $cacheDuration);
+proxyRequest($apiUrl, $apiHeaders, $cacheFile, $cacheDuration);
 
 ?>

--- a/public/php/netdataproxy.php
+++ b/public/php/netdataproxy.php
@@ -7,12 +7,12 @@
  *
  *     The script has a few additional advantages
  *       - We are caching the last results so we don't get rate limited
- *       - We can hide our API key in this script instead of the website
+ *       - We can hide our authentication headers in this script instead of the website
  *       - We add a header to show when the data is old
  *
  * Configuration:  The following variables can be set
  *     $apiUrl        = The API URL we are calling
- *     $apiKey        = The API Key
+ *     $apiHeaders    = An array of HTTP headers used for authentication
  *     $cacheFile     = Path to the cache file
  *     $cacheDuration = How many seconds to cache the response
  *
@@ -21,19 +21,19 @@
  */
 
 $apiUrl = "https://netdata.example.com/api/v2/nodes";
-$apiKey = "NotSet";
+$apiHeaders = [];
 $cacheFile = '../../cache/netdataproxy.cache';
 $cacheDuration = 14;
 
 include '../../config/netdataproxy.config';
 require_once 'common.php';
 
-if ($apiKey == "NotSet") {
+if (empty($apiHeaders)) {
     http_response_code(500);
-    echo json_encode(["success" => "false","error" => "API Key not set"]);
+    echo json_encode(["success" => "false","error" => "API headers not set"]);
     exit;
 }
 
-proxyRequest($apiUrl, $apiKey, $cacheFile, $cacheDuration);
+proxyRequest($apiUrl, $apiHeaders, $cacheFile, $cacheDuration);
 
 ?>


### PR DESCRIPTION
## Summary
- support custom authentication headers via `common.php`
- update config samples to define `$apiHeaders`
- document new `apiHeaders` option in README

## Testing
- `php -l public/php/common.php`
- `php -l public/php/appbeatproxy.php`
- `php -l public/php/netdataproxy.php`
- `php -l public/php/googlecalendar.php`


------
https://chatgpt.com/codex/tasks/task_e_685c2904c86c832cb81b8ed8a63311a7