### PR TITLE
Fix sirportly proxy parse error

### DIFF
--- a/public/php/sirportlyproxy.php
+++ b/public/php/sirportlyproxy.php
@@ -31,7 +31,7 @@ if (empty($apiHeaders)) {
     exit;
 }
 
-$SQL = 'SELECT%20COUNT%2Cusers.first_name%2Cusers.last_name%2Cstatus.name%2Cstatus.status_type%20FROM%20tickets%20WHERE%20statuses.status_type%20!%3D%201%20GROUP%20BY%20users.first_name%2Cusers.last_name%2Cstatus.name'
+$SQL = 'SELECT%20COUNT%2Cusers.first_name%2Cusers.last_name%2Cstatus.name%2Cstatus.status_type%20FROM%20tickets%20WHERE%20statuses.status_type%20!%3D%201%20GROUP%20BY%20users.first_name%2Cusers.last_name%2Cstatus.name';
 
 proxyRequest("$apiUrl/api/v2/tickets/spql?spql=$SQL", $apiHeaders, $cacheFile, $cacheDuration);
 


### PR DESCRIPTION
## Summary
- fix missing semicolon in sirportly proxy

## Testing
- `php -l public/php/sirportlyproxy.php`
- `php public/php/sirportlyproxy.php` *(fails to load config but no syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d27025180832c8c5b4f45894e57b7