### PR TITLE
Improve Sirportly table layout

### DIFF
--- a/public/css/business.css
+++ b/public/css/business.css
@@ -38,6 +38,29 @@ body {
   font-size: 24px;
   border-bottom: 1px solid #fff;
 }
+.section-sirportly .table {
+  margin-top: 20px;
+}
+
+.section-sirportly .table th:nth-child(1),
+.section-sirportly .table td:nth-child(1) {
+  width: 33%;
+}
+.section-sirportly .table th:nth-child(2),
+.section-sirportly .table td:nth-child(2) {
+  width: 67%;
+}
+
+.label-cell {
+  display: flex;
+  justify-content: space-between;
+}
+.label-cell .text {
+  text-align: left;
+}
+.label-cell .number {
+  text-align: right;
+}
 .table th {
   background-color: #fff;
 }
@@ -46,6 +69,8 @@ body {
   height: 24px;
   background-color: #eee;
   display: flex;
+  border-radius: 5px;
+  overflow: hidden;
 }
 .bar-segment {
   height: 100%;

--- a/public/js/sirportly.js
+++ b/public/js/sirportly.js
@@ -48,18 +48,22 @@ function fetchAndRenderSirportlyData() {
       return `<div class="bar-container">${segments.join('')}</div>`;
     }
 
+    function labelCell(label, count) {
+      return `<td class="label-cell"><span class="text">${label}</span><span class="number">${count}</span></td>`;
+    }
+
     const rows = [];
-    rows.push({ html: `<td>New ${counts.new}</td><td>${barHTML([segment(counts.new, 'bar-yellow')])}</td>`, status: '' });
-    rows.push({ html: `<td>Daily ${counts.daily}</td><td>${barHTML([segment(counts.daily, 'bar-yellow')])}</td>`, status: '' });
-    rows.push({ html: `<td>Waiting ${counts.waiting}</td><td>${barHTML([segment(counts.waiting, 'bar-yellow')])}</td>`, status: '' });
+    rows.push({ html: `${labelCell('New', counts.new)}<td>${barHTML([segment(counts.new, 'bar-yellow')])}</td>`, status: '' });
+    rows.push({ html: `${labelCell('Daily', counts.daily)}<td>${barHTML([segment(counts.daily, 'bar-yellow')])}</td>`, status: '' });
+    rows.push({ html: `${labelCell('Waiting', counts.waiting)}<td>${barHTML([segment(counts.waiting, 'bar-yellow')])}</td>`, status: '' });
 
     users.forEach(user => {
       const segs = [
-        segment(user.blue, 'bar-blue'),
         segment(user.red, 'bar-red'),
+        segment(user.blue, 'bar-blue'),
         segment(user.green, 'bar-green'),
       ];
-      rows.push({ html: `<td>${user.name} ${user.total}</td><td>${barHTML(segs)}</td>`, status: '' });
+      rows.push({ html: `${labelCell(user.name, user.total)}<td>${barHTML(segs)}</td>`, status: '' });
     });
 
     clearAndRenderTable('sirportlyTable', rows);


### PR DESCRIPTION
## Summary
- improve layout of the Sirportly table on the business page
  - reorder bar colours red-blue-green
  - width of columns now 1:2 ratio
  - number count aligned right with label left
  - add rounded corners on the bar chart
  - match calendar spacing

## Testing
- `node --check public/js/sirportly.js`

------
https://chatgpt.com/codex/tasks/task_e_685d7747a988832cb4cd5ec66531bd2f